### PR TITLE
Add ability to selectively run or skip tools

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -1,9 +1,16 @@
 
 params.total_reads = 10000 // Total number of reads per file (10k reads generates a ~1GB file)
-params.num_files = 10      // Number of FASTQ files to generate in parallel and concatenate
-params.small_files = 1000  // Number of small files to generate in a single process
+params.num_files    = 10    // Number of FASTQ files to generate in parallel and concatenate
+params.small_files  = 1000  // Number of small files to generate in a single process
+params.run         = null  // Tools to selectively run
+params.skip        = ''    // Tools to selectively skip
 
 process.container = 'quay.io/nextflow/bash'
-process.cpus = 4
-process.memory = { 2.GB * task.attempt }
-docker.enabled = true
+process.cpus      = 4
+process.memory    = { 2.GB * task.attempt }
+docker.enabled    = true
+
+process.when = { 
+    ( params.run ? params.run.split(',').any{ "${it.toUpperCase()}".contains(task.process) } : true ) && 
+    (!params.skip.split(',').any{ "${it.toUpperCase()}".contains(task.process) } ) 
+}

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://raw.githubusercontent.com//master/nextflow_schema.json",
+  "title": " pipeline parameters",
+  "description": "",
+  "type": "object",
+  "definitions": {
+    "input_output": {
+      "title": "Input/Output",
+      "type": "object",
+      "description": "",
+      "default": "",
+      "properties": {
+        "total_reads": {
+          "type": "integer",
+          "default": 10000,
+          "description": "Number of reads to generate per GENERATE_READS process."
+        },
+        "num_files": {
+          "type": "integer",
+          "default": 10,
+          "description": "Number of GENERATE_READS processes which generate a single FASTQ file."
+        },
+        "small_files": {
+          "type": "integer",
+          "default": 1000,
+          "description": "Number of miniature text files to generate in MANY_SMALL_FILES process"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/input_output"
+    }
+  ]
+}

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -27,11 +27,30 @@
           "description": "Number of miniature text files to generate in MANY_SMALL_FILES process"
         }
       }
+    },
+    "tool_selection": {
+      "title": "Tool Selection",
+      "type": "object",
+      "description": "",
+      "default": "",
+      "properties": {
+        "run": {
+          "type": "string",
+          "description": "Selectively run a tool. If this option is enabled only tools with this name will be ran. Note: this may affect downstream tools."
+        },
+        "skip": {
+          "type": "string",
+          "description": "Selectively disable a tool. If this option is enabled a tool will be ignored. Note: this may affect downstream tools."
+        }
+      }
     }
   },
   "allOf": [
     {
       "$ref": "#/definitions/input_output"
+    },
+    {
+      "$ref": "#/definitions/tool_selection"
     }
   ]
 }


### PR DESCRIPTION
This PR adds the ability to selectively run or skip tools. 

e.g., the following skips `GENERATE_FAKE_FASTQ`:
```
> nextflow run . --skip GENERATE_FAKE_FASTQ
N E X T F L O W  ~  version 24.04.4
Launching `./main.nf` [distraught_gilbert] DSL2 - revision: 91a757ade4
[ae/4ab85c] Submitted process > MANY_SMALL_FILES
[01/04ff0b] Submitted process > COUNT_FILES
[8f/eb67fb] Submitted process > COMPRESS_FILES
...
```

While this _only_ runs `MANY_SMALL_FILES`:

```
> nextflow run . --run MANY_SMALL_FILES
N E X T F L O W  ~  version 24.04.4
Launching `./main.nf` [dreamy_torricelli] DSL2 - revision: 91a757ade4
[9e/443861] Submitted process > MANY_SMALL_FILES
```