### PR TITLE
Add FASTQ files to testing operations

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -1,9 +1,11 @@
 
-params.total_reads = 10000 // Total number of reads per file (10k reads generates a ~1GB file)
-params.num_files    = 10    // Number of FASTQ files to generate in parallel and concatenate
-params.small_files  = 1000  // Number of small files to generate in a single process
-params.run         = null  // Tools to selectively run
-params.skip        = ''    // Tools to selectively skip
+params.total_reads    = 10000 // Total number of reads per file (10k reads generates a ~1GB file)
+params.num_files       = 10    // Number of FASTQ files to generate in parallel and concatenate
+params.small_files     = 1000  // Number of small files to generate in a single process
+params.run            = null  // Tools to selectively run
+params.skip           = ''    // Tools to selectively skip
+params.use_small_files = true  // Use small files in downstream operations
+params.use_fastq_files = false // Use FASTQ files in downstream operations
 
 process.container = 'quay.io/nextflow/bash'
 process.cpus      = 4

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -41,6 +41,15 @@
         "skip": {
           "type": "string",
           "description": "Selectively disable a tool. If this option is enabled a tool will be ignored. Note: this may affect downstream tools."
+        },
+        "use_small_files": {
+          "type": "boolean",
+          "default": true,
+          "description": "Add small files to downstream operations tests  (e.g. count, rename, compress)."
+        },
+        "use_fastq_files": {
+          "type": "boolean",
+          "description": "Use FASTQ files for downstream operations tests  (e.g. count, rename, compress)."
         }
       }
     }


### PR DESCRIPTION
This PR adds the ability to use the FASTQ files in downstream operations (e.g. rename, compress). This will allow us to add larger input files into the mix for pushing the limits of testing a bit more based on requirements.
