### PR TITLE
More linear pipeline structure for supporting multiple file types

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -1,5 +1,6 @@
 
 params.total_reads    = 10000 // Total number of reads per file (10k reads generates a ~1GB file)
+params.read_length    = 50    // Read length in generated FASTQ files
 params.num_files       = 10    // Number of FASTQ files to generate in parallel and concatenate
 params.small_files     = 1000  // Number of small files to generate in a single process
 params.run            = null  // Tools to selectively run

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,9 +1,11 @@
 
-params.total_reads = 10000 // Total number of reads per file (10k reads generates a ~1GB file)
-params.num_files    = 10    // Number of FASTQ files to generate in parallel and concatenate
-params.small_files  = 1000  // Number of small files to generate in a single process
-params.run         = null  // Tools to selectively run
-params.skip        = ''    // Tools to selectively skip
+params.total_reads    = 10000 // Total number of reads per file (10k reads generates a ~1GB file)
+params.num_files       = 10    // Number of FASTQ files to generate in parallel and concatenate
+params.small_files     = 1000  // Number of small files to generate in a single process
+params.run            = null  // Tools to selectively run
+params.skip           = ''    // Tools to selectively skip
+params.use_small_files = true  // Use small files in downstream operations
+params.use_fastq_files = false // Use FASTQ files in downstream operations
 
 process.container = 'quay.io/nextflow/bash'
 process.cpus      = 4

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,12 +1,17 @@
 
-params.total_reads    = 10000 // Total number of reads per file (10k reads generates a ~1GB file)
-params.read_length    = 50    // Read length in generated FASTQ files
-params.num_files       = 10    // Number of FASTQ files to generate in parallel and concatenate
-params.small_files     = 1000  // Number of small files to generate in a single process
-params.run            = null  // Tools to selectively run
-params.skip           = ''    // Tools to selectively skip
-params.use_small_files = true  // Use small files in downstream operations
-params.use_fastq_files = false // Use FASTQ files in downstream operations
+params.enable_fastq_files  = true  // Whether to generate FASTQ files or not
+params.fastq_n_files       = 10    // Number of FASTQ files to generate in parallel and concatenate
+params.fastq_n_reads      = 10000 // Total number of reads per file (10k reads generates a ~1GB file)
+params.fastq_read_length  = 53676 // Read length in generated FASTQ files
+params.process_fastq_files = false // Use FASTQ files in downstream operations
+
+params.enable_zero_files   = true  // Whether to generate zero files or not
+params.zero_n_files        = 1000  // Number of small files to generate in a single process
+params.zero_file_size      = 10
+params.process_zero_files = true  // Use small files in downstream operations
+
+params.run                = null  // Tools to selectively run
+params.skip               = ''    // Tools to selectively skip
 
 process.container = 'quay.io/nextflow/bash'
 process.cpus      = 4
@@ -16,4 +21,22 @@ docker.enabled    = true
 process.when = { 
     ( params.run ? params.run.split(',').any{ "${it.toUpperCase()}".contains(task.process) } : true ) && 
     (!params.skip.split(',').any{ "${it.toUpperCase()}".contains(task.process) } ) 
+}
+
+profiles {
+    test {
+        params.enable_fastq_files  = true  // Whether to generate FASTQ files or not
+        params.fastq_n_files       = 2     // Number of FASTQ files to generate in parallel and concatenate
+        params.fastq_n_reads      = 10    // Total number of reads per file (10k reads generates a ~1GB file)
+        params.fastq_read_length  = 50    // Read length in generated FASTQ files
+        params.process_fastq_files = false // Use FASTQ files in downstream operations
+
+        params.enable_zero_files   = true  // Whether to generate zero files or not
+        params.zero_n_files        = 10    // Number of small files to generate in a single process
+        params.zero_file_size      = 10
+        params.process_zero_files = true   // Use small files in downstream operations
+
+        params.run                = null  // Tools to selectively run
+        params.skip               = ''    // Tools to selectively skip
+    }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -29,7 +29,7 @@ profiles {
         params.fastq_n_files       = 2     // Number of FASTQ files to generate in parallel and concatenate
         params.fastq_n_reads      = 10    // Total number of reads per file (10k reads generates a ~1GB file)
         params.fastq_read_length  = 50    // Read length in generated FASTQ files
-        params.process_fastq_files = false // Use FASTQ files in downstream operations
+        params.process_fastq_files = true // Use FASTQ files in downstream operations
 
         params.enable_zero_files   = true  // Whether to generate zero files or not
         params.zero_n_files        = 10    // Number of small files to generate in a single process

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -5,31 +5,65 @@
   "description": "",
   "type": "object",
   "definitions": {
-    "input_output": {
-      "title": "Input/Output",
+    "generate_fastq_file_options": {
+      "title": "Generate FASTQ file options",
       "type": "object",
       "description": "",
       "default": "",
       "properties": {
-        "total_reads": {
-          "type": "integer",
-          "default": 10000,
-          "description": "Number of reads to generate per GENERATE_READS process."
+        "enable_fastq_files": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable generation of FASTQ files for filesystem testing."
         },
-        "num_files": {
+        "fastq_n_files": {
           "type": "integer",
           "default": 10,
-          "description": "Number of GENERATE_READS processes which generate a single FASTQ file."
+          "description": "Number of GENERATE_FASTQ processes which generate a single FASTQ file."
         },
-        "small_files": {
+        "fastq_n_reads": {
+          "type": "integer",
+          "default": 10000,
+          "description": "Number of reads to generate per GENERATE_FASTQ process."
+        },
+        "fastq_read_length": {
+          "type": "integer",
+          "default": 53676,
+          "description": "Length of FASTQ reads to generate."
+        },
+        "process_fastq_files": {
+          "type": "boolean",
+          "description": "Whether to include FASTQ files in downstream file operations such as compress, archive, rename etc.",
+          "hidden": true
+        }
+      }
+    },
+    "dev_zero_file_options": {
+      "title": "/dev/zero file options",
+      "type": "object",
+      "description": "",
+      "default": "",
+      "properties": {
+        "enable_zero_files": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable generation of files from /dev/zero for filesystem testing."
+        },
+        "zero_n_files": {
           "type": "integer",
           "default": 1000,
-          "description": "Number of miniature text files to generate in MANY_SMALL_FILES process"
+          "description": "Number of miniature text files to generate from /dev/zero."
         },
-        "read_length": {
+        "zero_file_size": {
           "type": "integer",
-          "default": 50,
-          "description": "Length of FASTQ reads to generate."
+          "default": 10,
+          "description": "Size of zero file to generate in megabytes."
+        },
+        "process_zero_files": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to include zero files in downstream file operations such as compress, archive, rename etc.",
+          "hidden": true
         }
       }
     },
@@ -46,22 +80,16 @@
         "skip": {
           "type": "string",
           "description": "Selectively disable a tool. If this option is enabled a tool will be ignored. Note: this may affect downstream tools."
-        },
-        "use_small_files": {
-          "type": "boolean",
-          "default": true,
-          "description": "Add small files to downstream operations tests  (e.g. count, rename, compress)."
-        },
-        "use_fastq_files": {
-          "type": "boolean",
-          "description": "Use FASTQ files for downstream operations tests  (e.g. count, rename, compress)."
         }
       }
     }
   },
   "allOf": [
     {
-      "$ref": "#/definitions/input_output"
+      "$ref": "#/definitions/generate_fastq_file_options"
+    },
+    {
+      "$ref": "#/definitions/dev_zero_file_options"
     },
     {
       "$ref": "#/definitions/tool_selection"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -8,7 +8,7 @@
     "generate_fastq_file_options": {
       "title": "Generate FASTQ file options",
       "type": "object",
-      "description": "FASTQ files that are generated within the pipeline that are realistic representations of sequencing data.",
+      "description": "Options relating to FASTQ files that are generated within the pipeline that are realistic representations of sequencing data.",
       "default": "",
       "properties": {
         "enable_fastq_files": {
@@ -41,7 +41,7 @@
     "zero_file_options": {
       "title": "Zero file options",
       "type": "object",
-      "description": "Files that are generated within the pipeline composed entirely of zeros to be used for small file manipulation.",
+      "description": "Options that are related to files that are generated within the pipeline composed entirely of zeros to be used for small file manipulation.",
       "default": "",
       "properties": {
         "enable_zero_files": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -41,6 +41,15 @@
         "skip": {
           "type": "string",
           "description": "Selectively disable a tool. If this option is enabled a tool will be ignored. Note: this may affect downstream tools."
+        },
+        "use_small_files": {
+          "type": "boolean",
+          "default": true,
+          "description": "Add small files to downstream operations tests  (e.g. count, rename, compress)."
+        },
+        "use_fastq_files": {
+          "type": "boolean",
+          "description": "Use FASTQ files for downstream operations tests  (e.g. count, rename, compress)."
         }
       }
     }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -8,7 +8,7 @@
     "generate_fastq_file_options": {
       "title": "Generate FASTQ file options",
       "type": "object",
-      "description": "",
+      "description": "FASTQ files that are generated within the pipeline that are realistic representations of sequencing data.",
       "default": "",
       "properties": {
         "enable_fastq_files": {
@@ -38,10 +38,10 @@
         }
       }
     },
-    "dev_zero_file_options": {
-      "title": "/dev/zero file options",
+    "zero_file_options": {
+      "title": "Zero file options",
       "type": "object",
-      "description": "",
+      "description": "Files that are generated within the pipeline composed entirely of zeros to be used for small file manipulation.",
       "default": "",
       "properties": {
         "enable_zero_files": {
@@ -89,7 +89,7 @@
       "$ref": "#/definitions/generate_fastq_file_options"
     },
     {
-      "$ref": "#/definitions/dev_zero_file_options"
+      "$ref": "#/definitions/zero_file_options"
     },
     {
       "$ref": "#/definitions/tool_selection"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -25,6 +25,11 @@
           "type": "integer",
           "default": 1000,
           "description": "Number of miniature text files to generate in MANY_SMALL_FILES process"
+        },
+        "read_length": {
+          "type": "integer",
+          "default": 50,
+          "description": "Length of FASTQ reads to generate."
         }
       }
     },


### PR DESCRIPTION
This PR changes the pipeline structure so that it uses a more linear set of steps and can be controlled.

Changes:
 - Create FASTQ and create files composed of zeros are performed at the start of the pipeline
 - They are fed into subsequent processes for file manipulations
 - The two file types are manipulated together but can be switched on or off based on flags

Advantages:
 - This is a more flexible structure which means we can extend it to new file types when they are necessary
 - We can perform the file manipulations on larger or smaller files by enabling or disabling features
 - We have granular control over more aspects of the pipeline

Disadvantage
 - Separate file operations cannot be performed on each file type, since they are mixed. We can disable individual processes though.
 - It may be necessary to launch multiple pipelines to test multiple things instead of one test with multiple hypotheses
 - If statements (yuck)

Supercedes #3, closes #4
