### PR TITLE
Compress small files one by one in parallel instead of a big tar.gz

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -206,6 +206,6 @@ workflow {
     RENAME_AND_COMPRESS_FILES(small_files.files)
 
     // Extract and verify checksum of all the files
-    UNCOMPRESS_FILES(RENAME_AND_COMPRESS_FILES.out, small_files.checksum)
+    UNCOMPRESS_AND_VERIFY_FILES(RENAME_AND_COMPRESS_FILES.out, small_files.checksum)
 
 }

--- a/main.nf
+++ b/main.nf
@@ -1,6 +1,9 @@
 process GENERATE_FAKE_FASTQ {
     container 'community.wave.seqera.io/library/numpy:2.1.1--3063fc3d721f2cdf'
 
+    cpus 2
+    memory { 4.GB * task.attempt }
+
     input:
     tuple val(total_reads), val(file_index)
 
@@ -43,6 +46,10 @@ process GENERATE_FAKE_FASTQ {
 }
 
 process CONCATENATE_FASTQ {
+
+    cpus 4
+    memory { 12.GB * task.attempt }
+
     input:
     path fastq_files
 
@@ -56,6 +63,10 @@ process CONCATENATE_FASTQ {
 }
 
 process CHECKSUM_FASTQ {
+
+    cpus 4
+    memory { 6.GB * task.attempt }
+
     input:
     path fastq_file
 
@@ -71,6 +82,9 @@ process CHECKSUM_FASTQ {
 process COMPRESS_FASTQ {
     container 'community.wave.seqera.io/library/pigz:2.8--cc287835d69f818b'
 
+    cpus 16
+    memory { 48.GB * task.attempt }
+
     input:
     path fastq_file
 
@@ -84,6 +98,10 @@ process COMPRESS_FASTQ {
 }
 
 process MANY_SMALL_FILES {
+
+    cpus 2
+    memory { 6.GB * task.attempt }
+
     input:
     val num_files
 
@@ -106,6 +124,10 @@ process MANY_SMALL_FILES {
 }
 
 process COUNT_FILES {
+
+    cpus 2
+    memory { 6.GB * task.attempt }
+
     input:
     path files_folder
 
@@ -121,6 +143,9 @@ process COUNT_FILES {
 
 process RENAME_AND_COMPRESS_FILES {
     container 'community.wave.seqera.io/library/parallel:20240322--aeca7ef865f0e18b'
+
+    cpus 16
+    memory { 48.GB * task.attempt }
 
     input:
     path files_folder
@@ -148,6 +173,9 @@ process RENAME_AND_COMPRESS_FILES {
 
 process UNCOMPRESS_AND_VERIFY_FILES {
     container 'community.wave.seqera.io/library/parallel:20240322--aeca7ef865f0e18b'
+
+    cpus 16
+    memory { 48.GB * task.attempt }
 
     input:
     path files_folder

--- a/nextflow.config
+++ b/nextflow.config
@@ -7,7 +7,7 @@ params.skip        = ''    // Tools to selectively skip
 
 process.container = 'quay.io/nextflow/bash'
 process.cpus      = 4
-process.memory    = { 4.GB * task.attempt }
+process.memory    = { 12.GB * task.attempt }
 docker.enabled    = true
 
 process.when = { 

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,8 +6,6 @@ params.run         = null  // Tools to selectively run
 params.skip        = ''    // Tools to selectively skip
 
 process.container = 'quay.io/nextflow/bash'
-process.cpus      = 4
-process.memory    = { 12.GB * task.attempt }
 docker.enabled    = true
 
 process.when = { 


### PR DESCRIPTION
## Changelog

- On the big flow, I added the `CHECKSUM_FASTQ` that reads a big file, does some fast computing, and writes a small file. In this process, I want to benchmark processes that read big files but do not stress the disk writing into them.

- Use `find` instead of expanded glob patterns to avoid the error "command line too long" when working with many files.

- Use `parallel` when working with many small files

- Remove the process that was creating one big `tar.gz`. In the "small files" flow, we want to test only working on small files, and that was creating one big file, so we already benchmarked this on the other flow.

- On the small files flow, I added compression one by one in parallel to add some CPU load when working with small files.

- Set CPU and memory requirements depending on the process and allowing to support more load 